### PR TITLE
fix: Docker startup issues (BACKEND_PORT and server.js path)

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 FROM node:22-alpine AS builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 WORKDIR /app
 
@@ -23,46 +23,51 @@ RUN pnpm --filter @logarr/backend build
 # Production stage
 FROM node:22-alpine AS runner
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 WORKDIR /app
 
 ENV NODE_ENV=production
 
+# Create non-root user
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nestjs
+
 # Copy package files
-COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
-COPY turbo.json ./
+COPY --chown=nestjs:nodejs package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY --chown=nestjs:nodejs turbo.json ./
 
 # Copy built packages - core
-COPY --from=builder /app/packages/core/package.json ./packages/core/
-COPY --from=builder /app/packages/core/dist ./packages/core/dist
+COPY --from=builder --chown=nestjs:nodejs /app/packages/core/package.json ./packages/core/
+COPY --from=builder --chown=nestjs:nodejs /app/packages/core/dist ./packages/core/dist
 
 # Copy built packages - providers
-COPY --from=builder /app/packages/provider-arr/package.json ./packages/provider-arr/
-COPY --from=builder /app/packages/provider-arr/dist ./packages/provider-arr/dist
-COPY --from=builder /app/packages/provider-jellyfin/package.json ./packages/provider-jellyfin/
-COPY --from=builder /app/packages/provider-jellyfin/dist ./packages/provider-jellyfin/dist
-COPY --from=builder /app/packages/provider-sonarr/package.json ./packages/provider-sonarr/
-COPY --from=builder /app/packages/provider-sonarr/dist ./packages/provider-sonarr/dist
-COPY --from=builder /app/packages/provider-radarr/package.json ./packages/provider-radarr/
-COPY --from=builder /app/packages/provider-radarr/dist ./packages/provider-radarr/dist
-COPY --from=builder /app/packages/provider-prowlarr/package.json ./packages/provider-prowlarr/
-COPY --from=builder /app/packages/provider-prowlarr/dist ./packages/provider-prowlarr/dist
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-arr/package.json ./packages/provider-arr/
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-arr/dist ./packages/provider-arr/dist
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-jellyfin/package.json ./packages/provider-jellyfin/
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-jellyfin/dist ./packages/provider-jellyfin/dist
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-sonarr/package.json ./packages/provider-sonarr/
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-sonarr/dist ./packages/provider-sonarr/dist
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-radarr/package.json ./packages/provider-radarr/
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-radarr/dist ./packages/provider-radarr/dist
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-prowlarr/package.json ./packages/provider-prowlarr/
+COPY --from=builder --chown=nestjs:nodejs /app/packages/provider-prowlarr/dist ./packages/provider-prowlarr/dist
 
 # Copy backend
-COPY --from=builder /app/apps/backend/package.json ./apps/backend/
-COPY --from=builder /app/apps/backend/dist ./apps/backend/dist
-COPY --from=builder /app/apps/backend/drizzle ./apps/backend/drizzle
-COPY --from=builder /app/apps/backend/drizzle.config.ts ./apps/backend/
-COPY --from=builder /app/apps/backend/src/database ./apps/backend/src/database
+COPY --from=builder --chown=nestjs:nodejs /app/apps/backend/package.json ./apps/backend/
+COPY --from=builder --chown=nestjs:nodejs /app/apps/backend/dist ./apps/backend/dist
+COPY --from=builder --chown=nestjs:nodejs /app/apps/backend/drizzle ./apps/backend/drizzle
+COPY --from=builder --chown=nestjs:nodejs /app/apps/backend/drizzle.config.ts ./apps/backend/
+COPY --from=builder --chown=nestjs:nodejs /app/apps/backend/src/database ./apps/backend/src/database
 
 # Install production dependencies + drizzle-kit for migrations
-RUN pnpm install --frozen-lockfile --prod
-RUN pnpm add -w drizzle-kit
+RUN pnpm install --frozen-lockfile --prod && pnpm add -w drizzle-kit
+
+USER nestjs
 
 # Expose port
 EXPOSE 4000
 
 # Start the application with migrations
 WORKDIR /app/apps/backend
-CMD ["sh", "-c", "pnpm drizzle-kit push && node dist/main.js"]
+CMD ["sh", "-c", "npx drizzle-kit push && node dist/main.js"]

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 FROM node:22-alpine AS builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 WORKDIR /app
 
@@ -16,8 +16,8 @@ COPY apps/frontend/ ./apps/frontend/
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Build packages first
-RUN pnpm --filter @loggerr/core build || true
+# Build shared packages first (if they exist)
+RUN pnpm --filter "@logarr/*" build || true
 
 # Set build-time environment variables
 ARG NEXT_PUBLIC_API_URL=http://localhost:4001/api
@@ -46,8 +46,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/.next/static ./apps
 COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/public ./apps/frontend/public
 
 # Copy entrypoint script
-COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/docker-entrypoint.sh ./apps/frontend/
-RUN chmod +x ./apps/frontend/docker-entrypoint.sh
+COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/docker-entrypoint.sh ./
+RUN chmod +x ./docker-entrypoint.sh
 
 USER nextjs
 
@@ -56,5 +56,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-WORKDIR /app/apps/frontend
 CMD ["./docker-entrypoint.sh"]

--- a/apps/frontend/docker-entrypoint.sh
+++ b/apps/frontend/docker-entrypoint.sh
@@ -24,5 +24,5 @@ echo "Runtime config generated:"
 echo "  API URL: ${NEXT_PUBLIC_API_URL}"
 echo "  WS URL: ${NEXT_PUBLIC_WS_URL}"
 
-# Start the application
-exec node server.js
+# Start the application (server.js is at /app in standalone monorepo output)
+exec node /app/apps/frontend/server.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:16-alpine
@@ -49,8 +47,14 @@ services:
       NODE_ENV: production
       DATABASE_URL: postgresql://postgres:postgres@db:5432/logarr
       REDIS_URL: redis://redis:6379
-      PORT: 4000
-      CORS_ORIGIN: http://localhost:3002
+      BACKEND_PORT: 4000
+      CORS_ORIGIN: http://localhost:3001
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:4000/api']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     depends_on:
       db:
         condition: service_healthy
@@ -69,8 +73,16 @@ services:
       - '3001:3000'
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:4001/api
+      NEXT_PUBLIC_WS_URL: ws://localhost:4001
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - logarr-network
 


### PR DESCRIPTION
## Summary

Fixes two critical issues preventing Docker containers from starting:

**Backend (`BACKEND_PORT: Expected number, received nan`):**
- Changed `PORT` to `BACKEND_PORT` in docker-compose.yml (backend env.ts expects `BACKEND_PORT`)
- Fixed `CORS_ORIGIN` to use correct port 3001

**Frontend (`Cannot find module '/app/server.js'`):**
- Fixed server.js path to `/app/apps/frontend/server.js` (monorepo standalone output places it there)
- Added missing `NEXT_PUBLIC_WS_URL` environment variable

**Production hardening:**
- Removed obsolete docker-compose `version` attribute
- Added non-root user (`nestjs`) to backend Dockerfile
- Added healthchecks for backend and frontend containers
- Pinned pnpm to 9.15.0 for reproducible builds
- Fixed `@loggerr/core` typo to `@logarr/*` in frontend Dockerfile
- Added `--chown` to COPY commands in backend Dockerfile

## Test plan

- [x] Built containers from scratch with `--no-cache`
- [x] All 4 containers start successfully (db, redis, backend, frontend)
- [x] All healthchecks pass
- [x] Backend API returns healthy status
- [x] Frontend serves dashboard correctly

Closes #2