### PR TITLE
fix: Complete file-based log ingestion configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ LOG_CLEANUP_BATCH_SIZE=10000    # Rows deleted per batch (tune for your hardware
 
 # Media Server Logs Paths (optional - for file-based log ingestion)
 # These are HOST paths that get mounted into Docker containers.
-# In the Sources UI, configure the CONTAINER paths: /plex-logs or /jellyfin-logs
+# In the Sources UI, configure the CONTAINER paths: /plex-logs, /jellyfin-logs, etc.
 #
 # Plex examples:
 #   Windows: C:/Users/YourName/AppData/Local/Plex Media Server/Logs
@@ -44,3 +44,27 @@ PLEX_LOGS_PATH=
 #   Linux:   /var/lib/jellyfin/log
 #   Docker:  /path/to/jellyfin/config/log
 JELLYFIN_LOGS_PATH=
+
+# Emby examples:
+#   Windows: C:/ProgramData/Emby-Server/logs
+#   Linux:   /var/lib/emby/logs
+#   Docker:  /path/to/emby/config/logs
+EMBY_LOGS_PATH=
+
+# Sonarr examples (container path: /sonarr-logs):
+#   Windows: C:/ProgramData/Sonarr/logs
+#   Linux:   ~/.config/Sonarr/logs
+#   Docker:  /path/to/sonarr/config/logs
+SONARR_LOGS_PATH=
+
+# Radarr examples (container path: /radarr-logs):
+#   Windows: C:/ProgramData/Radarr/logs
+#   Linux:   ~/.config/Radarr/logs
+#   Docker:  /path/to/radarr/config/logs
+RADARR_LOGS_PATH=
+
+# Prowlarr examples (container path: /prowlarr-logs):
+#   Windows: C:/ProgramData/Prowlarr/logs
+#   Linux:   ~/.config/Prowlarr/logs
+#   Docker:  /path/to/prowlarr/config/logs
+PROWLARR_LOGS_PATH=

--- a/README.md
+++ b/README.md
@@ -220,6 +220,50 @@ Issues and statistics are preserved even after logs are deleted. The Data Manage
 2. Select server type and enter URL + API key
 3. Test connection and save
 
+### File-Based Log Ingestion
+
+For deeper log analysis, Logarr can read log files directly from your media servers. This captures detailed application logs that APIs don't expose.
+
+#### Setup (Docker)
+
+1. **Set log paths in `.env`** — Point to your host machine's log directories:
+
+```bash
+# Media Servers
+PLEX_LOGS_PATH=/path/to/plex/Library/Application Support/Plex Media Server/Logs
+JELLYFIN_LOGS_PATH=/path/to/jellyfin/config/log
+EMBY_LOGS_PATH=/path/to/emby/config/logs
+
+# *arr Apps
+SONARR_LOGS_PATH=/path/to/sonarr/config/logs
+RADARR_LOGS_PATH=/path/to/radarr/config/logs
+PROWLARR_LOGS_PATH=/path/to/prowlarr/config/logs
+```
+
+1. **Restart Logarr** — The docker-compose mounts these paths automatically.
+
+1. **Configure in UI** — Go to **Sources** → Edit your server → Enable file ingestion with the container path:
+
+| Server   | Container Path    |
+| -------- | ----------------- |
+| Plex     | `/plex-logs`      |
+| Jellyfin | `/jellyfin-logs`  |
+| Emby     | `/emby-logs`      |
+| Sonarr   | `/sonarr-logs`    |
+| Radarr   | `/radarr-logs`    |
+| Prowlarr | `/prowlarr-logs`  |
+
+#### Common Log Locations
+
+| Server   | Docker                        | Linux                              | Windows                                           |
+| -------- | ----------------------------- | ---------------------------------- | ------------------------------------------------- |
+| Plex     | `/config/Library/.../Logs`    | `/var/lib/plexmediaserver/.../Logs`| `%LOCALAPPDATA%\Plex Media Server\Logs`           |
+| Jellyfin | `/config/log`                 | `/var/lib/jellyfin/log`            | `C:\ProgramData\Jellyfin\Server\log`              |
+| Emby     | `/config/logs`                | `/var/lib/emby/logs`               | `C:\ProgramData\Emby-Server\logs`                 |
+| Sonarr   | `/config/logs`                | `~/.config/Sonarr/logs`            | `C:\ProgramData\Sonarr\logs`                      |
+| Radarr   | `/config/logs`                | `~/.config/Radarr/logs`            | `C:\ProgramData\Radarr\logs`                      |
+| Prowlarr | `/config/logs`                | `~/.config/Prowlarr/logs`          | `C:\ProgramData\Prowlarr\logs`                    |
+
 ---
 
 ## API Reference
@@ -313,16 +357,7 @@ pnpm test:e2e          # Run Playwright E2E tests
 
 ## Roadmap
 
-This project is under active development and we're looking for contributors to help shape its direction.
-
-Some ideas on the table:
-
-- Additional providers (Kodi, Lidarr, Readarr)
-- Alerting integrations (Slack, Discord, email)
-- ~~Log retention policies~~ ✅ Implemented
-- Custom dashboards
-
-Have other ideas? [Open an issue](https://github.com/itz4blitz/logarr/issues) or jump into a discussion.
+This project is under active development. Check out our [GitHub Discussions](https://github.com/itz4blitz/logarr/discussions) for feature requests, ideas, and community conversations.
 
 ---
 

--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -11,7 +11,7 @@ COPY . .
 RUN pnpm install
 
 # Build packages first (core -> provider-arr -> provider-jellyfin, provider-sonarr, provider-radarr, provider-prowlarr, provider-plex)
-RUN pnpm build --filter @logarr/core --filter @logarr/provider-arr --filter @logarr/provider-jellyfin --filter @logarr/provider-sonarr --filter @logarr/provider-radarr --filter @logarr/provider-prowlarr --filter @logarr/provider-plex
+RUN pnpm build --filter @logarr/core --filter @logarr/provider-arr --filter @logarr/provider-jellyfin --filter @logarr/provider-sonarr --filter @logarr/provider-radarr --filter @logarr/provider-prowlarr --filter @logarr/provider-plex --filter @logarr/provider-emby
 
 EXPOSE 4002
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,6 +63,7 @@ services:
       - ./packages/provider-radarr/src:/app/packages/provider-radarr/src
       - ./packages/provider-prowlarr/src:/app/packages/provider-prowlarr/src
       - ./packages/provider-plex/src:/app/packages/provider-plex/src
+      - ./packages/provider-emby/src:/app/packages/provider-emby/src
       - ./apps/backend/src:/app/apps/backend/src
       # Mount tsconfig files
       - ./tsconfig.json:/app/tsconfig.json
@@ -73,14 +74,19 @@ services:
       - ./packages/provider-radarr/tsconfig.json:/app/packages/provider-radarr/tsconfig.json
       - ./packages/provider-prowlarr/tsconfig.json:/app/packages/provider-prowlarr/tsconfig.json
       - ./packages/provider-plex/tsconfig.json:/app/packages/provider-plex/tsconfig.json
+      - ./packages/provider-emby/tsconfig.json:/app/packages/provider-emby/tsconfig.json
       - ./apps/backend/tsconfig.json:/app/apps/backend/tsconfig.json
       # Mount media server logs (optional - for file-based log ingestion)
-      # Set PLEX_LOGS_PATH and JELLYFIN_LOGS_PATH in .env to LOCAL paths
+      # Set *_LOGS_PATH vars in .env to LOCAL paths on your host machine
       # Note: Docker Desktop cannot mount network drives (Z:, mapped shares)
       # For network shares, run backend natively or use local paths
-      # In Sources UI, use container paths: /plex-logs and /jellyfin-logs
+      # In Sources UI, use container paths: /plex-logs, /jellyfin-logs, etc.
       - ${PLEX_LOGS_PATH:-./logs/plex}:/plex-logs:ro
       - ${JELLYFIN_LOGS_PATH:-./logs/jellyfin}:/jellyfin-logs:ro
+      - ${EMBY_LOGS_PATH:-./logs/emby}:/emby-logs:ro
+      - ${SONARR_LOGS_PATH:-./logs/sonarr}:/sonarr-logs:ro
+      - ${RADARR_LOGS_PATH:-./logs/radarr}:/radarr-logs:ro
+      - ${PROWLARR_LOGS_PATH:-./logs/prowlarr}:/prowlarr-logs:ro
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,15 @@ services:
       REDIS_URL: redis://redis:6379
       BACKEND_PORT: 4000
       CORS_ORIGIN: http://localhost:3001
+    volumes:
+      # Media server log mounts (optional - set paths in .env for file-based log ingestion)
+      # In the Sources UI, configure paths as: /plex-logs, /jellyfin-logs, /emby-logs, etc.
+      - ${PLEX_LOGS_PATH:-/dev/null}:/plex-logs:ro
+      - ${JELLYFIN_LOGS_PATH:-/dev/null}:/jellyfin-logs:ro
+      - ${EMBY_LOGS_PATH:-/dev/null}:/emby-logs:ro
+      - ${SONARR_LOGS_PATH:-/dev/null}:/sonarr-logs:ro
+      - ${RADARR_LOGS_PATH:-/dev/null}:/radarr-logs:ro
+      - ${PROWLARR_LOGS_PATH:-/dev/null}:/prowlarr-logs:ro
     healthcheck:
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:4000/api']
       interval: 30s

--- a/packages/provider-emby/src/emby.provider.ts
+++ b/packages/provider-emby/src/emby.provider.ts
@@ -102,7 +102,8 @@ export class EmbyProvider implements MediaServerProvider {
 
     // Default Emby log paths for different platforms
     return Promise.resolve([
-      '/config/logs', // Docker
+      '/emby-logs', // Docker with Logarr (mount via EMBY_LOGS_PATH env var)
+      '/config/logs', // Docker (Emby container)
       '/var/lib/emby/logs', // Linux
       '/var/lib/emby-server/logs', // Linux alternative
       'C:\\ProgramData\\Emby-Server\\logs', // Windows

--- a/packages/provider-jellyfin/src/jellyfin.provider.ts
+++ b/packages/provider-jellyfin/src/jellyfin.provider.ts
@@ -86,7 +86,8 @@ export class JellyfinProvider implements MediaServerProvider {
 
     // Default Jellyfin log paths for different platforms
     return Promise.resolve([
-      '/config/log', // Docker
+      '/jellyfin-logs', // Docker with Logarr (mount via JELLYFIN_LOGS_PATH env var)
+      '/config/log', // Docker (Jellyfin container)
       '/var/lib/jellyfin/log', // Linux
       'C:\\ProgramData\\Jellyfin\\Server\\log', // Windows
     ]);

--- a/packages/provider-plex/src/plex.provider.ts
+++ b/packages/provider-plex/src/plex.provider.ts
@@ -103,7 +103,8 @@ export class PlexProvider implements MediaServerProvider {
 
     // Default Plex log paths for different platforms
     return Promise.resolve([
-      '/config/Library/Application Support/Plex Media Server/Logs', // Docker
+      '/plex-logs', // Docker with Logarr (mount via PLEX_LOGS_PATH env var)
+      '/config/Library/Application Support/Plex Media Server/Logs', // Docker (Plex container)
       '/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Logs', // Linux
       'C:\\Users\\*\\AppData\\Local\\Plex Media Server\\Logs', // Windows
       '~/Library/Application Support/Plex Media Server/Logs', // macOS

--- a/packages/provider-prowlarr/src/prowlarr.provider.ts
+++ b/packages/provider-prowlarr/src/prowlarr.provider.ts
@@ -91,6 +91,24 @@ export class ProwlarrProvider extends ArrBaseProvider {
   }
 
   /**
+   * Override log paths with Prowlarr-specific defaults
+   */
+  override getLogPaths(): Promise<readonly string[]> {
+    if (this.config?.logPath !== undefined) {
+      return Promise.resolve([this.config.logPath]);
+    }
+
+    // Default Prowlarr log paths for different platforms
+    return Promise.resolve([
+      '/prowlarr-logs', // Docker with Logarr (mount via PROWLARR_LOGS_PATH env var)
+      '/config/logs', // Docker (Prowlarr container)
+      '~/.config/Prowlarr/logs', // Linux
+      '/var/lib/prowlarr/logs', // Linux alternative
+      'C:\\ProgramData\\Prowlarr\\logs', // Windows
+    ]);
+  }
+
+  /**
    * Override log file config with Prowlarr-specific paths
    */
   override getLogFileConfig(): LogFileConfig {

--- a/packages/provider-radarr/src/radarr.provider.ts
+++ b/packages/provider-radarr/src/radarr.provider.ts
@@ -95,6 +95,24 @@ export class RadarrProvider extends ArrBaseProvider {
   }
 
   /**
+   * Override log paths with Radarr-specific defaults
+   */
+  override getLogPaths(): Promise<readonly string[]> {
+    if (this.config?.logPath !== undefined) {
+      return Promise.resolve([this.config.logPath]);
+    }
+
+    // Default Radarr log paths for different platforms
+    return Promise.resolve([
+      '/radarr-logs', // Docker with Logarr (mount via RADARR_LOGS_PATH env var)
+      '/config/logs', // Docker (Radarr container)
+      '~/.config/Radarr/logs', // Linux
+      '/var/lib/radarr/logs', // Linux alternative
+      'C:\\ProgramData\\Radarr\\logs', // Windows
+    ]);
+  }
+
+  /**
    * Override log file config with Radarr-specific paths
    */
   override getLogFileConfig(): LogFileConfig {

--- a/packages/provider-sonarr/src/sonarr.provider.ts
+++ b/packages/provider-sonarr/src/sonarr.provider.ts
@@ -98,6 +98,24 @@ export class SonarrProvider extends ArrBaseProvider {
   }
 
   /**
+   * Override log paths with Sonarr-specific defaults
+   */
+  override getLogPaths(): Promise<readonly string[]> {
+    if (this.config?.logPath !== undefined) {
+      return Promise.resolve([this.config.logPath]);
+    }
+
+    // Default Sonarr log paths for different platforms
+    return Promise.resolve([
+      '/sonarr-logs', // Docker with Logarr (mount via SONARR_LOGS_PATH env var)
+      '/config/logs', // Docker (Sonarr container)
+      '~/.config/Sonarr/logs', // Linux
+      '/var/lib/sonarr/logs', // Linux alternative
+      'C:\\ProgramData\\Sonarr\\logs', // Windows
+    ]);
+  }
+
+  /**
    * Override log file config with Sonarr-specific paths
    */
   override getLogFileConfig(): LogFileConfig {


### PR DESCRIPTION
## Summary

- Add volume mounts for all providers (Plex, Jellyfin, Emby, Sonarr, Radarr, Prowlarr) in production docker-compose.yml
- Add missing Emby and *arr log mounts to docker-compose.dev.yml
- Add provider-emby to Dockerfile.dev build command
- Add `getLogPaths()` overrides to Sonarr, Radarr, Prowlarr providers with Logarr mount paths
- Update all media server providers to check `/xxx-logs` mount paths first
- Add `SONARR_LOGS_PATH`, `RADARR_LOGS_PATH`, `PROWLARR_LOGS_PATH` to .env.example
- Add comprehensive file ingestion setup guide to README
- Simplify roadmap section to link to GitHub Discussions

## Test plan

- [ ] Verify docker-compose.yml mounts work with env vars set
- [ ] Verify docker-compose.yml mounts fall back to /dev/null when unset
- [ ] Verify providers return correct default paths
- [ ] Verify README documentation is accurate