### PR TITLE
fix: Docker for Windows frontend startup failure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Shell scripts should always use LF line endings (Unix-style)
+*.sh text eol=lf
+
+# Other files that should use LF
+Dockerfile* text eol=lf
+.dockerignore text eol=lf
+Makefile text eol=lf
+
+# Git config files
+.gitattributes text eol=lf
+.gitignore text eol=lf

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -45,9 +45,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/.next/static ./apps/frontend/.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/public ./apps/frontend/public
 
-# Copy entrypoint script
+# Copy entrypoint script and fix line endings (handles Windows CRLF issue)
 COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/docker-entrypoint.sh ./
-RUN chmod +x ./docker-entrypoint.sh
+RUN sed -i 's/\r$//' ./docker-entrypoint.sh && chmod +x ./docker-entrypoint.sh
 
 USER nextjs
 


### PR DESCRIPTION
## Summary
- Fixes frontend container crash on Docker for Windows with error: `exec: ./docker-entrypoint.sh: not found`
- Root cause: CRLF line endings in shell script causing shebang to become `#!/bin/sh\r` (not found)

## Changes
- Add `.gitattributes` to enforce LF line endings for shell scripts, Dockerfiles, and other Unix-sensitive files
- Add `sed` command in Dockerfile to strip CRLF as a fallback for users who clone without proper git configuration

## Testing
- Reproduced the issue on Docker for Windows
- Verified fix works with fresh `docker compose build --no-cache && docker compose up -d`
- All containers now start successfully and frontend is accessible at http://localhost:3001

Related to #15