### PR TITLE
feat: add upgrade support with pre-built Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,76 @@ logarr/
 
 ---
 
+## Upgrading
+
+Logarr uses pre-built Docker images by default, making upgrades simple:
+
+### Automatic Upgrade Script
+
+**Linux/Mac:**
+
+```bash
+chmod +x update.sh
+./update.sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+.\update.ps1
+```
+
+### Manual Upgrade
+
+```bash
+docker compose down
+docker compose pull
+docker compose up -d
+```
+
+### Pinning to a Specific Version
+
+By default, Logarr uses the `:latest` tag. To pin to a specific version (recommended for production):
+
+```bash
+# In your .env file or docker-compose.yml
+LOGARR_VERSION=0.5.4
+```
+
+Or set it per-run:
+
+```bash
+LOGARR_VERSION=0.5.4 docker compose up -d
+```
+
+### Building from Source
+
+If you prefer to build from source instead of using pre-built images:
+
+```bash
+# Set environment variable to enable local builds
+LOGARR_BUILD_LOCALLY=1
+
+# Or build manually
+docker compose build --no-cache
+docker compose up -d
+```
+
+### Image Registries
+
+Logarr images are published to:
+
+- **GitHub Container Registry:** `ghcr.io/itz4blitz/logarr-backend` and `ghcr.io/itz4blitz/logarr-frontend`
+- **Docker Hub:** `itz4blitz/logarr-backend` and `itz4blitz/logarr-frontend`
+
+To use Docker Hub instead of GHCR:
+
+```bash
+LOGARR_IMAGE_REGISTRY=docker.io/itz4blitz
+```
+
+---
+
 ## Contributing
 
 ```bash

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logarr/backend",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "description": "Logarr NestJS backend API",
   "scripts": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - logarr-network
 
   backend:
+    # Use pre-built images by default. Set LOGARR_BUILD_LOCALLY=true to build from source instead.
+    image: ${LOGARR_IMAGE_REGISTRY:-ghcr.io/itz4blitz}/logarr-backend:${LOGARR_VERSION:-latest}
     build:
       context: .
       dockerfile: apps/backend/Dockerfile
@@ -154,6 +156,8 @@ services:
       - logarr-network
 
   frontend:
+    # Use pre-built images by default. Set LOGARR_BUILD_LOCALLY=true to build from source instead.
+    image: ${LOGARR_IMAGE_REGISTRY:-ghcr.io/itz4blitz}/logarr-frontend:${LOGARR_VERSION:-latest}
     build:
       context: .
       dockerfile: apps/frontend/Dockerfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logarr",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "description": "Unified logging for your media stack",
   "scripts": {

--- a/update.ps1
+++ b/update.ps1
@@ -1,0 +1,48 @@
+# Logarr Update Script for Windows
+# Updates Logarr to the latest version
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Logarr Update Script ===" -ForegroundColor Green
+Write-Host ""
+
+# Check if docker compose is available
+try {
+    docker compose version | Out-Null
+} catch {
+    Write-Host "Error: docker is not installed or not running" -ForegroundColor Red
+    exit 1
+}
+
+# Check if we're in the logarr directory
+if (-not (Test-Path "docker-compose.yml")) {
+    Write-Host "Error: docker-compose.yml not found. Are you in the logarr directory?" -ForegroundColor Red
+    exit 1
+}
+
+# Stop running containers
+Write-Host "Stopping containers..." -ForegroundColor Yellow
+docker compose down
+Write-Host ""
+
+# Pull latest images
+Write-Host "Pulling latest images..." -ForegroundColor Green
+docker compose pull
+Write-Host ""
+
+# Start containers
+Write-Host "Starting containers..." -ForegroundColor Yellow
+docker compose up -d
+Write-Host ""
+
+# Wait for services
+Write-Host "Waiting for services to start..." -ForegroundColor Yellow
+Start-Sleep -Seconds 5
+
+# Show status
+Write-Host "Container status:" -ForegroundColor Green
+docker compose ps
+Write-Host ""
+
+Write-Host "=== Update complete! ===" -ForegroundColor Green
+Write-Host "Logarr should be running on http://localhost:3001"

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Logarr Update Script
+# Updates Logarr to the latest version
+
+set -e
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}=== Logarr Update Script ===${NC}"
+echo ""
+
+# Check if docker compose is available
+if ! command -v docker &> /dev/null; then
+    echo "Error: docker is not installed"
+    exit 1
+fi
+
+# Check if we're in the logarr directory
+if [ ! -f "docker-compose.yml" ]; then
+    echo "Error: docker-compose.yml not found. Are you in the logarr directory?"
+    exit 1
+fi
+
+# Stop running containers
+echo -e "${YELLOW}Stopping containers...${NC}"
+docker compose down
+echo ""
+
+# Pull latest images
+echo -e "${GREEN}Pulling latest images...${NC}"
+docker compose pull
+echo ""
+
+# Start containers
+echo -e "${YELLOW}Starting containers...${NC}"
+docker compose up -d
+echo ""
+
+# Wait for services
+echo -e "${YELLOW}Waiting for services to start...${NC}"
+sleep 5
+
+# Show status
+echo -e "${GREEN}Container status:${NC}"
+docker compose ps
+echo ""
+
+echo -e "${GREEN}=== Update complete! ===${NC}"
+echo "Logarr should be running on http://localhost:3001"


### PR DESCRIPTION
- Update docker-compose.yml to use pre-built images from GHCR/Docker Hub by default
- Add update.sh and update.ps1 scripts for easy upgrades
- Add Upgrading section to README with version pinning options
- Users can now simply run 'docker compose pull' to update

Resolves question about upgrade process for users.