### PR TITLE
fix: handle empty strings in optional env vars

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logarr/backend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Logarr NestJS backend API",
   "scripts": {

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -27,7 +27,14 @@ let validatedEnv: Env | null = null;
 export function validateEnv(): Env {
   if (validatedEnv) return validatedEnv;
 
-  const result = envSchema.safeParse(process.env);
+  // Convert empty strings to undefined for optional fields
+  // This allows commented-out env vars to work properly
+  const sanitizedEnv: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    sanitizedEnv[key] = value === '' ? undefined : value;
+  }
+
+  const result = envSchema.safeParse(sanitizedEnv);
 
   if (!result.success) {
     console.error('\n❌ Invalid environment configuration:\n');

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logarr",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Unified logging for your media stack",
   "scripts": {


### PR DESCRIPTION
Empty strings from commented-out env vars were causing validation errors.

Now converts empty strings to undefined before validation, allowing optional
fields like ADMIN_PASSWORD_RESET to be safely commented out in .env files.

Fixes #37