### PR TITLE
release: bump app version to v0.6.4

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logarr/backend",
-  "version": "0.6.1",
+  "version": "0.6.4",
   "private": true,
   "description": "Logarr NestJS backend API",
   "scripts": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.6.1",
+  "version": "0.6.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logarr",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "description": "Unified logging for your media stack",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the root, frontend, and backend package versions to 0.6.4 so the shipped app version matches the published release

## Validation
- pnpm --filter @logarr/backend typecheck
- NODE_ENV=production pnpm exec dotenv -e .env -- pnpm --filter frontend build