### PR TITLE
fix: skip docker workflow for agent-only changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,16 @@ on:
   push:
     branches: [master]
     tags: ['v*']
+    paths-ignore:
+      - '.github/agents/**'
+      - '.github/instructions/**'
+      - '.github/copilot-instructions.md'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '.github/agents/**'
+      - '.github/instructions/**'
+      - '.github/copilot-instructions.md'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- add `paths-ignore` rules so agent and instruction-only changes do not trigger the Docker build/test workflow
- keep normal code changes and release tag pushes eligible for the existing CI pipeline
- isolate this change on its own branch so it can merge independently of other local work in progress

## Testing
- verified the branch diff against `origin/master` contains only `.github/workflows/docker-publish.yml`
- no application tests were run because this change only adjusts GitHub Actions trigger conditions